### PR TITLE
WFLY-3044 / JAVASERVERFACES-3191 Mojarra's @ViewScoped implementation is...

### DIFF
--- a/jsf-api/src/main/java/javax/faces/view/ViewScoped.java
+++ b/jsf-api/src/main/java/javax/faces/view/ViewScoped.java
@@ -115,7 +115,7 @@ import javax.enterprise.context.NormalScope;
 
  * @since 2.2
  */
-@NormalScope
+@NormalScope(passivating = true)
 @Inherited
 @Documented
 @Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})

--- a/jsf-ri/src/main/java/com/sun/faces/application/view/ViewScopeContextObject.java
+++ b/jsf-ri/src/main/java/com/sun/faces/application/view/ViewScopeContextObject.java
@@ -39,6 +39,7 @@
  */
 package com.sun.faces.application.view;
 
+import java.io.Serializable;
 import javax.enterprise.context.spi.Contextual;
 import javax.enterprise.context.spi.CreationalContext;
 
@@ -46,7 +47,7 @@ import javax.enterprise.context.spi.CreationalContext;
  * An object used by ViewScopeContext to keep track of contextual and creational
  * context.
  */
-class ViewScopeContextObject {
+class ViewScopeContextObject implements Serializable {
 
     /**
      * Stores the contextual.


### PR DESCRIPTION
... not cluster-aware resulting in NotSerializableException

Seems to do the job.

Commented also on https://java.net/jira/browse/JAVASERVERFACES-3191?focusedCommentId=373570&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#action_373570
