### PR TITLE
[BZ-1270758] Regression JAVASERVERFACES-4074 - didn't correct all uses of getExternalContext().isSecure()

### DIFF
--- a/test/agnostic/flash/wrappedExtContext/nbactions.xml
+++ b/test/agnostic/flash/wrappedExtContext/nbactions.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 1997-2010 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+--><actions>
+        <action>
+            <actionName>debug.test.single</actionName>
+            <goals>
+                <goal>test-compile</goal>
+                <goal>surefire:test</goal>
+            </goals>
+            <properties>
+                <test>wrappedExtContext</test>
+                <forkMode>once</forkMode>
+                <maven.surefire.debug>-Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address}</maven.surefire.debug>
+                <webapp.enableClientStateDebugging>true</webapp.enableClientStateDebugging>
+                <jpda.listen>true</jpda.listen>
+                <project.build.finalName>test-agnostic-flash-wrappedExtContext</project.build.finalName>
+                <webapp.projectStage>Development</webapp.projectStage>
+                <webapp.stateSavingMethod>client</webapp.stateSavingMethod>
+                <integration.serverPort>8080</integration.serverPort>
+                <integration.serverName>localhost</integration.serverName>
+                <integration.url>http://localhost:8080/test-agnostic-flash-wrappedExtContext/</integration.url>
+                <webapp.partialStateSaving>false</webapp.partialStateSaving>
+            </properties>
+        </action>
+        <action>
+            <actionName>test.single</actionName>
+            <goals>
+                <goal>test-compile</goal>
+                <goal>surefire:test</goal>
+            </goals>
+            <properties>
+                <project.build.finalName>test-agnostic-flash-wrappedExtContext</project.build.finalName>
+                <integration.serverPort>8080</integration.serverPort>
+                <integration.serverName>localhost</integration.serverName>
+                <integration.url>http://localhost:8080/test-agnostic-flash-wrappedExtContext/</integration.url>
+                <test>wrappedExtContext</test>
+            </properties>
+        </action>
+        <action>
+            <actionName>build</actionName>
+            <goals>
+                <goal>install</goal>
+            </goals>
+            <properties>
+                <webapp.projectStage>Development</webapp.projectStage>
+                <webapp.partialStateSaving>false</webapp.partialStateSaving>
+                <webapp.enableClientStateDebugging>true</webapp.enableClientStateDebugging>
+                <webapp.stateSavingMethod>client</webapp.stateSavingMethod>
+            </properties>
+        </action>
+        <action>
+            <actionName>rebuild</actionName>
+            <goals>
+                <goal>clean</goal>
+                <goal>install</goal>
+            </goals>
+            <properties>
+                
+                <webapp.partialStateSaving>false</webapp.partialStateSaving>
+                
+                <webapp.projectStage>Development</webapp.projectStage>
+                
+                <webapp.enableClientStateDebugging>true</webapp.enableClientStateDebugging>
+                
+                <webapp.stateSavingMethod>client</webapp.stateSavingMethod>
+                
+            </properties>
+        </action>
+        <action>
+            <actionName>build-with-dependencies</actionName>
+            <reactor>also-make</reactor>
+            <goals>
+                <goal>install</goal>
+            </goals>
+            <properties>
+                <webapp.partialStateSaving>false</webapp.partialStateSaving>
+                <webapp.stateSavingMethod>client</webapp.stateSavingMethod>
+                <webapp.enableClientStateDebugging>true</webapp.enableClientStateDebugging>
+                <webapp.projectStage>Development</webapp.projectStage>
+            </properties>
+        </action>
+        <action>
+            <actionName>run</actionName>
+            <goals>
+                <goal>package</goal>
+            </goals>
+            <properties>
+                <webapp.partialStateSaving>false</webapp.partialStateSaving>
+                <netbeans.deploy>true</netbeans.deploy>
+                <webapp.enableClientStateDebugging>true</webapp.enableClientStateDebugging>
+                <webapp.stateSavingMethod>client</webapp.stateSavingMethod>
+                <webapp.projectStage>Development</webapp.projectStage>
+            </properties>
+        </action>
+        <action>
+            <actionName>run.single.deploy</actionName>
+            <goals>
+                <goal>package</goal>
+            </goals>
+            <properties>
+                <webapp.partialStateSaving>false</webapp.partialStateSaving>
+                <netbeans.deploy>true</netbeans.deploy>
+                <webapp.enableClientStateDebugging>true</webapp.enableClientStateDebugging>
+                <netbeans.deploy.clientUrlPart>${webpagePath}</netbeans.deploy.clientUrlPart>
+                <webapp.stateSavingMethod>client</webapp.stateSavingMethod>
+                <webapp.projectStage>Development</webapp.projectStage>
+            </properties>
+        </action>
+        <action>
+            <actionName>debug.single.deploy</actionName>
+            <goals>
+                <goal>package</goal>
+            </goals>
+            <properties>
+                <webapp.partialStateSaving>false</webapp.partialStateSaving>
+                <netbeans.deploy>true</netbeans.deploy>
+                <webapp.enableClientStateDebugging>true</webapp.enableClientStateDebugging>
+                <netbeans.deploy.debugmode>true</netbeans.deploy.debugmode>
+                <netbeans.deploy.clientUrlPart>${webpagePath}</netbeans.deploy.clientUrlPart>
+                <webapp.stateSavingMethod>client</webapp.stateSavingMethod>
+                <webapp.projectStage>Development</webapp.projectStage>
+            </properties>
+        </action>
+    </actions>

--- a/test/agnostic/flash/wrappedExtContext/pom.xml
+++ b/test/agnostic/flash/wrappedExtContext/pom.xml
@@ -39,20 +39,25 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
---><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>com.sun.faces.test.agnostic</groupId>
-        <artifactId>pom</artifactId>
-        <version>2.1.28-SNAPSHOT</version>
-    </parent>
-    <groupId>com.sun.faces.test.agnostic.flash</groupId>
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
     <artifactId>pom</artifactId>
-    <packaging>pom</packaging>
-    <name>Mojarra ${project.version} - Test - Agnostic - Flash</name>
-    <modules>
-        <module>basic</module>
-        <module>chunkRedirect</module>
-    <module>wrappedExtContext</module>
-  </modules>
+    <groupId>com.sun.faces.test.agnostic.flash</groupId>
+    <version>2.1.29-SNAPSHOT</version>
+  </parent>
+  
+  <groupId>com.sun.faces.test.agnostic.flash</groupId>
+  <artifactId>wrappedExtContext</artifactId>
+  <version>2.1.29-SNAPSHOT</version>
+  <packaging>war</packaging>
+  <name>Mojarra ${project.version} - Test - Agnostic - Flash - Wrapped External Context</name>
+  
+  <build>
+    <finalName>test-agnostic-flash-wrappedExtContext</finalName>
+  </build>
+    <properties>
+        <netbeans.hint.deploy.server>gfv3ee6</netbeans.hint.deploy.server>
+    </properties>
 </project>

--- a/test/agnostic/flash/wrappedExtContext/src/main/java/cic1440b/Cic1440bBean.java
+++ b/test/agnostic/flash/wrappedExtContext/src/main/java/cic1440b/Cic1440bBean.java
@@ -1,0 +1,56 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 1997-2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package cic1440b;
+
+import javax.faces.bean.ApplicationScoped;
+import javax.faces.bean.ManagedBean;
+import javax.faces.context.FacesContext;
+
+@ManagedBean
+@ApplicationScoped
+public class Cic1440bBean {
+
+	public String submit() {
+		
+		FacesContext.getCurrentInstance().getExternalContext().getFlash().putNow("aaa", "xxx");
+		return "/second?faces-redirect=true";
+	}
+}

--- a/test/agnostic/flash/wrappedExtContext/src/main/java/cic1440b/MyExternalContext.java
+++ b/test/agnostic/flash/wrappedExtContext/src/main/java/cic1440b/MyExternalContext.java
@@ -1,0 +1,234 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 1997-2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package cic1440b;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Map;
+import javax.faces.context.ExternalContext;
+import javax.faces.context.ExternalContextWrapper;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+public class MyExternalContext extends ExternalContextWrapper {
+
+	private final ExternalContext wrapped;
+
+	public MyExternalContext(ExternalContext wrapped) {
+		this.wrapped = wrapped;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ExternalContext getWrapped() {
+		return wrapped;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getRequestContextPath() {
+
+		return wrapped.getRequestContextPath();
+	}
+
+    @Override
+    public Object getRequest() {
+        final HttpServletRequest wrappedRequest = (HttpServletRequest) super.getRequest();
+        Object result = new MyPortletRequest() {
+
+            public boolean isWindowStateAllowed(Object state) {
+                return false;
+            }
+
+            public boolean isPortletModeAllowed(Object mode) {
+                return false;
+            }
+
+            public Object getObject() {
+                return this;
+            }
+
+            public Object getPreferences() {
+                return this;
+            }
+
+            public Object getObject(boolean create) {
+                return this;
+            }
+
+            public String getProperty(String name) {
+                return (String) wrappedRequest.getAttribute(name);
+            }
+
+            public Enumeration<String> getProperties(String name) {
+                return wrappedRequest.getAttributeNames();
+            }
+
+            public Enumeration<String> getPropertyNames() {
+                return wrappedRequest.getAttributeNames();
+            }
+
+            public Object getPortalContext() {
+                return this;
+            }
+
+            public String getAuthType() {
+                return wrappedRequest.getAuthType();
+            }
+
+            public String getContextPath() {
+                return wrappedRequest.getContextPath();
+            }
+
+            public String getRemoteUser() {
+                return wrappedRequest.getRemoteUser();
+            }
+
+            public Principal getUserPrincipal() {
+                return wrappedRequest.getUserPrincipal();
+            }
+
+            public boolean isUserInRole(String role) {
+                return wrappedRequest.isUserInRole(role);
+            }
+
+            public Object getAttribute(String name) {
+                return wrappedRequest.getAttribute(name);
+            }
+
+            public Enumeration<String> getAttributeNames() {
+                return wrappedRequest.getAttributeNames();
+            }
+
+            public String getParameter(String name) {
+                return wrappedRequest.getParameter(name);
+            }
+
+            public Enumeration<String> getParameterNames() {
+                return wrappedRequest.getParameterNames();
+            }
+
+            public String[] getParameterValues(String name) {
+                return wrappedRequest.getParameterValues(name);
+            }
+
+            public Map<String, String[]> getParameterMap() {
+                return wrappedRequest.getParameterMap();
+            }
+
+            public boolean isSecure() {
+                return wrappedRequest.isSecure();
+            }
+
+            public void setAttribute(String name, Object o) {
+                wrappedRequest.setAttribute(name, o);
+            }
+
+            public void removeAttribute(String name) {
+                wrappedRequest.removeAttribute(name);
+            }
+
+            public String getRequestedSessionId() {
+                return wrappedRequest.getSession().getId();
+            }
+
+            public boolean isRequestedSessionIdValid() {
+                return true;
+            }
+
+            public String getResponseContentType() {
+                return wrappedRequest.getContentType(); // lie
+            }
+
+            public Enumeration<String> getResponseContentTypes() {
+                return wrappedRequest.getHeaderNames(); // lie
+            }
+
+            public Locale getLocale() {
+                return wrappedRequest.getLocale();
+            }
+
+            public Enumeration<Locale> getLocales() {
+                return wrappedRequest.getLocales();
+            }
+
+            public String getScheme() {
+                return wrappedRequest.getScheme();
+            }
+
+            public String getServerName() {
+                return wrappedRequest.getServerName();
+            }
+
+            public int getServerPort() {
+                return wrappedRequest.getServerPort();
+            }
+
+            public String getWindowID() {
+                return "";
+            }
+
+            public Cookie[] getCookies() {
+                return wrappedRequest.getCookies();
+            }
+
+            public Map<String, String[]> getPrivateParameterMap() {
+                return Collections.EMPTY_MAP;
+            }
+
+            public Map<String, String[]> getPublicParameterMap() {
+                return Collections.EMPTY_MAP;
+            }
+        };
+        
+        return result;
+    }
+    
+    
+        
+        
+}

--- a/test/agnostic/flash/wrappedExtContext/src/main/java/cic1440b/MyExternalContextFactory.java
+++ b/test/agnostic/flash/wrappedExtContext/src/main/java/cic1440b/MyExternalContextFactory.java
@@ -1,0 +1,70 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 1997-2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package cic1440b;
+
+import javax.faces.context.ExternalContext;
+import javax.faces.context.ExternalContextFactory;
+
+public class MyExternalContextFactory extends ExternalContextFactory {
+
+	private final ExternalContextFactory wrapped;
+
+	public MyExternalContextFactory(ExternalContextFactory wrapped) {
+		this.wrapped = wrapped;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ExternalContextFactory getWrapped() {
+		return wrapped;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ExternalContext getExternalContext(Object servletContext, Object request, Object response) {
+
+		return new MyExternalContext(getWrapped().getExternalContext(servletContext, request, response));
+	}
+}

--- a/test/agnostic/flash/wrappedExtContext/src/main/java/cic1440b/MyPortletRequest.java
+++ b/test/agnostic/flash/wrappedExtContext/src/main/java/cic1440b/MyPortletRequest.java
@@ -1,0 +1,291 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 1997-2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package cic1440b;
+
+import java.util.Locale;
+
+public interface MyPortletRequest
+{
+    
+  public static final String USER_INFO = "javax.portlet.userinfo";
+
+  public static final String CCPP_PROFILE = "javax.portlet.ccpp";
+
+  public static final String BASIC_AUTH = "BASIC";
+
+  public static final String FORM_AUTH = "FORM";
+
+  public static final String CLIENT_CERT_AUTH = "CLIENT_CERT";
+
+  public static final String DIGEST_AUTH = "DIGEST";
+
+  public enum P3PUserInfos {
+      USER_BDATE_YMD_YEAR("user.bdate.ymd.year"), USER_BDATE_YMD_MONTH("user.bdate.ymd.month"),
+      USER_BDATE_YMD_DAY("user.bdate.ymd.day"), USER_BDATE_HMS_HOUR("user.bdate.hms.hour"),
+	  USER_BDATE_HMS_MINUTE("user.bdate.hms.minute"), USER_BDATE_HMS_SECOND("user.bdate.hms.second"),
+	  USER_BDATE_FRACTIONSECOND("user.bdate.fractionsecond"), USER_BDATE_TIMEZONE("user.bdate.timezone"),
+	  USER_GENDER("user.gender"), USER_EMPLOYER("user.employer"), 
+      USER_DEPARTMENT("user.department"), USER_JOBTITLE("user.jobtitle"), 
+      USER_NAME_PREFIX("user.name.prefix"), USER_NAME_GIVEN("user.name.given"), 
+      USER_NAME_FAMILY("user.name.family"), USER_NAME_MIDDLE("user.name.middle"),
+      USER_NAME_SUFFIX("user.name.suffix"), USER_NAME_NICKNAME("user.name.nickName"),
+      USER_LOGIN_ID("user.login.id"),
+      USER_HOMEINFO_POSTAL_NAME("user.home-info.postal.name"), 
+      USER_HOMEINFO_POSTAL_STREET("user.home-info.postal.street"),
+      USER_HOMEINFO_POSTAL_CITY("user.home-info.postal.city"), 
+      USER_HOMEINFO_POSTAL_STATEPROV("user.home-info.postal.stateprov"),
+      USER_HOMEINFO_POSTAL_POSTALCODE("user.home-info.postal.postalcode"),
+      USER_HOMEINFO_POSTAL_COUNTRY("user.home-info.postal.country"), 
+      USER_HOMEINFO_POSTAL_ORGANIZATION("user.home-info.postal.organization"), 
+      USER_HOMEINFO_TELECOM_TELEPHONE_INTCODE("user.home-info.telecom.telephone.intcode"),
+      USER_HOMEINFO_TELECOM_TELEPHONE_LOCCODE("user.home-info.telecom.telephone.loccode"),
+      USER_HOMEINFO_TELECOM_TELEPHONE_NUMBER("user.home-info.telecom.telephone.number"),
+      USER_HOMEINFO_TELECOM_TELEPHONE_EXT("user.home-info.telecom.telephone.ext"),
+      USER_HOMEINFO_TELECOM_TELEPHONE_COMMENT("user.home-info.telecom.telephone.comment"),
+      USER_HOMEINFO_TELECOM_FAX_INTCODE("user.home-info.telecom.fax.intcode"),
+      USER_HOMEINFO_TELECOM_FAX_LOCCODE("user.home-info.telecom.fax.loccode"),
+      USER_HOMEINFO_TELECOM_FAX_NUMBER("user.home-info.telecom.fax.number"),
+      USER_HOMEINFO_TELECOM_FAX_EXT("user.home-info.telecom.fax.ext"),
+      USER_HOMEINFO_TELECOM_FAX_COMMENT("user.home-info.telecom.fax.comment"),
+      USER_HOMEINFO_TELECOM_MOBILE_INTCODE("user.home-info.telecom.mobile.intcode"),
+      USER_HOMEINFO_TELECOM_MOBILE_LOCCODE("user.home-info.telecom.mobile.loccode"),
+      USER_HOMEINFO_TELECOM_MOBILE_NUMBER("user.home-info.telecom.mobile.number"),
+      USER_HOMEINFO_TELECOM_MOBILE_EXT("user.home-info.telecom.mobile.ext"),
+      USER_HOMEINFO_TELECOM_MOBILE_COMMENT("user.home-info.telecom.mobile.comment"),
+      USER_HOMEINFO_TELECOM_PAGER_INTCODE("user.home-info.telecom.pager.intcode"),
+      USER_HOMEINFO_TELECOM_PAGER_LOCCODE("user.home-info.telecom.pager.loccode"),
+      USER_HOMEINFO_TELECOM_PAGER_NUMBER("user.home-info.telecom.pager.number"),
+      USER_HOMEINFO_TELECOM_PAGER_EXT("user.home-info.telecom.pager.ext"),
+      USER_HOMEINFO_TELECOM_PAGER_COMMENT("user.home-info.telecom.pager.comment"),
+      USER_HOMEINFO_ONLINE_EMAIL("user.home-info.online.email"),
+      USER_HOMEINFO_ONLINE_URI("user.home-info.online.uri"),
+      USER_BUSINESSINFO_POSTAL_NAME("user.business-info.postal.name"), 
+      USER_BUSINESSINFO_POSTAL_STREET("user.business-info.postal.street"),
+      USER_BUSINESSINFO_POSTAL_CITY("user.business-info.postal.city"), 
+      USER_BUSINESSINFO_POSTAL_STATEPROV("user.business-info.postal.stateprov"),
+      USER_BUSINESSINFO_POSTAL_POSTALCODE("user.business-info.postal.postalcode"),
+      USER_BUSINESSINFO_POSTAL_COUNTRY("user.business-info.postal.country"), 
+      USER_BUSINESSINFO_POSTAL_ORGANIZATION("user.business-info.postal.organization"), 
+      USER_BUSINESSINFO_TELECOM_TELEPHONE_INTCODE("user.business-info.telecom.telephone.intcode"),
+      USER_BUSINESSINFO_TELECOM_TELEPHONE_LOCCODE("user.business-info.telecom.telephone.loccode"),
+      USER_BUSINESSINFO_TELECOM_TELEPHONE_NUMBER("user.business-info.telecom.telephone.number"),
+      USER_BUSINESSINFO_TELECOM_TELEPHONE_EXT("user.business-info.telecom.telephone.ext"),
+      USER_BUSINESSINFO_TELECOM_TELEPHONE_COMMENT("user.business-info.telecom.telephone.comment"),
+      USER_BUSINESSINFO_TELECOM_FAX_INTCODE("user.business-info.telecom.fax.intcode"),
+      USER_BUSINESSINFO_TELECOM_FAX_LOCCODE("user.business-info.telecom.fax.loccode"),
+      USER_BUSINESSINFO_TELECOM_FAX_NUMBER("user.business-info.telecom.fax.number"),
+      USER_BUSINESSINFO_TELECOM_FAX_EXT("user.business-info.telecom.fax.ext"),
+      USER_BUSINESSINFO_TELECOM_FAX_COMMENT("user.business-info.telecom.fax.comment"),
+      USER_BUSINESSINFO_TELECOM_MOBILE_INTCODE("user.business-info.telecom.mobile.intcode"),
+      USER_BUSINESSINFO_TELECOM_MOBILE_LOCCODE("user.business-info.telecom.mobile.loccode"),
+      USER_BUSINESSINFO_TELECOM_MOBILE_NUMBER("user.business-info.telecom.mobile.number"),
+      USER_BUSINESSINFO_TELECOM_MOBILE_EXT("user.business-info.telecom.mobile.ext"),
+      USER_BUSINESSINFO_TELECOM_MOBILE_COMMENT("user.business-info.telecom.mobile.comment"),
+      USER_BUSINESSINFO_TELECOM_PAGER_INTCODE("user.business-info.telecom.pager.intcode"),
+      USER_BUSINESSINFO_TELECOM_PAGER_LOCCODE("user.business-info.telecom.pager.loccode"),
+      USER_BUSINESSINFO_TELECOM_PAGER_NUMBER("user.business-info.telecom.pager.number"),
+      USER_BUSINESSINFO_TELECOM_PAGER_EXT("user.business-info.telecom.pager.ext"),
+      USER_BUSINESSINFO_TELECOM_PAGER_COMMENT("user.business-info.telecom.pager.comment"),
+      USER_BUSINESSINFO_ONLINE_EMAIL("user.business-info.online.email"),
+      USER_BUSINESSINFO_ONLINE_URI("user.business-info.online.uri");
+      P3PUserInfos(String value) {this.value = value; }
+      private final String value;
+      public String toString() {return value;}
+  }
+  
+  public static final String ACTION_PHASE = "ACTION_PHASE";
+  
+  public static final String EVENT_PHASE = "EVENT_PHASE";
+  
+  public static final String RENDER_PHASE = "RENDER_PHASE";
+  
+  public static final String RESOURCE_PHASE = "RESOURCE_PHASE";
+    
+  public static final String LIFECYCLE_PHASE = "javax.portlet.lifecycle_phase";
+  
+  
+  public static final String RENDER_PART = "javax.portlet.render_part";
+  
+  public static final String RENDER_HEADERS = "RENDER_HEADERS";
+
+  public static final String RENDER_MARKUP = "RENDER_MARKUP";
+
+  public static final String ACTION_SCOPE_ID = "javax.portlet.as";
+  
+  
+  public boolean isWindowStateAllowed(Object state);
+
+
+
+  public boolean isPortletModeAllowed(Object mode);
+
+
+
+  public Object getObject ();
+
+
+
+  public Object getPreferences ();
+
+
+
+  public Object getObject (boolean create);
+
+
+		
+
+  public String getProperty(String name); 
+
+
+		
+  
+  public java.util.Enumeration<String> getProperties(String name); 
+    
+    
+
+  public java.util.Enumeration<String> getPropertyNames();
+    
+    
+
+  public Object getPortalContext();
+
+
+
+  public java.lang.String getAuthType();
+  
+
+
+  public String getContextPath();
+
+
+
+  public java.lang.String getRemoteUser();
+
+
+
+  public java.security.Principal getUserPrincipal();
+
+
+
+  public boolean isUserInRole(java.lang.String role);
+
+
+
+  public Object getAttribute(String name);
+
+
+  
+  public java.util.Enumeration<String> getAttributeNames();
+
+
+  
+  public String getParameter(String name);
+
+
+
+  public java.util.Enumeration<String> getParameterNames();
+
+
+
+  public String[] getParameterValues(String name);
+
+
+
+  public java.util.Map<String, String[]> getParameterMap();
+
+
+
+  public boolean isSecure();
+
+
+  
+  public void setAttribute(String name, Object o);
+
+
+
+  public void removeAttribute(String name);
+
+   
+
+  public String getRequestedSessionId();
+
+
+
+  public boolean isRequestedSessionIdValid();
+
+
+
+  public String getResponseContentType();
+
+
+
+  public java.util.Enumeration<String> getResponseContentTypes();
+
+
+
+  public java.util.Locale getLocale();
+
+
+
+  public java.util.Enumeration<Locale> getLocales();
+
+
+
+  public String getScheme();
+    
+
+
+  public String getServerName();
+    
+    
+
+  public int getServerPort();
+
+  public String getWindowID();
+  
+  
+  public javax.servlet.http.Cookie[] getCookies();
+  
+  public java.util.Map<String, String[]> getPrivateParameterMap();
+  
+  public java.util.Map<String, String[]> getPublicParameterMap();
+
+}

--- a/test/agnostic/flash/wrappedExtContext/src/main/webapp/WEB-INF/faces-config.xml
+++ b/test/agnostic/flash/wrappedExtContext/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<faces-config
+    xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_1.xsd"
+    version="2.1">
+	<factory>
+        <external-context-factory>cic1440b.MyExternalContextFactory</external-context-factory>
+	</factory>
+	
+</faces-config>

--- a/test/agnostic/flash/wrappedExtContext/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/agnostic/flash/wrappedExtContext/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE glassfish-web-app PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Servlet 3.0//EN" "http://glassfish.org/dtds/glassfish-web-app_3_0-1.dtd">
+<glassfish-web-app error-url="">
+  <context-root>/test-agnostic-flash-wrappedExtContext</context-root>
+  <class-loader delegate="true"/>
+  <jsp-config>
+    <property name="keepgenerated" value="true">
+      <description>Keep a copy of the generated servlet class' java code.</description>
+    </property>
+  </jsp-config>
+</glassfish-web-app>

--- a/test/agnostic/flash/wrappedExtContext/src/main/webapp/WEB-INF/web.xml
+++ b/test/agnostic/flash/wrappedExtContext/src/main/webapp/WEB-INF/web.xml
@@ -39,20 +39,30 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
---><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>com.sun.faces.test.agnostic</groupId>
-        <artifactId>pom</artifactId>
-        <version>2.1.28-SNAPSHOT</version>
-    </parent>
-    <groupId>com.sun.faces.test.agnostic.flash</groupId>
-    <artifactId>pom</artifactId>
-    <packaging>pom</packaging>
-    <name>Mojarra ${project.version} - Test - Agnostic - Flash</name>
-    <modules>
-        <module>basic</module>
-        <module>chunkRedirect</module>
-    <module>wrappedExtContext</module>
-  </modules>
-</project>
+-->
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <context-param>
+        <param-name>javax.faces.PROJECT_STAGE</param-name>
+        <param-value>${webapp.projectStage}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>javax.faces.PARTIAL_STATE_SAVING</param-name>
+        <param-value>${webapp.partialStateSaving}</param-value>
+    </context-param>
+    <context-param>
+        <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
+        <param-value>${webapp.stateSavingMethod}</param-value>
+    </context-param>
+    <servlet>
+        <servlet-name>Faces Servlet</servlet-name>
+        <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>Faces Servlet</servlet-name>
+        <url-pattern>/faces/*</url-pattern>
+    </servlet-mapping>
+    <welcome-file-list>
+        <welcome-file>faces/first.xhtml</welcome-file>
+    </welcome-file-list>
+</web-app>

--- a/test/agnostic/flash/wrappedExtContext/src/main/webapp/first.xhtml
+++ b/test/agnostic/flash/wrappedExtContext/src/main/webapp/first.xhtml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:f="http://java.sun.com/jsf/core"
+      xmlns:h="http://java.sun.com/jsf/html"
+	  xmlns:ui="http://java.sun.com/jsf/facelets"
+      >
+
+    <h:body>
+        <h1>First</h1>
+        <h:form prependId="false">
+        	<h:commandButton id="submit" value="Submit" action="#{cic1440bBean.submit}"/>
+        </h:form>
+    </h:body>
+</html>

--- a/test/agnostic/flash/wrappedExtContext/src/main/webapp/second.xhtml
+++ b/test/agnostic/flash/wrappedExtContext/src/main/webapp/second.xhtml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:f="http://java.sun.com/jsf/core"
+      xmlns:h="http://java.sun.com/jsf/html"
+	  xmlns:ui="http://java.sun.com/jsf/facelets"
+      >
+
+    <h:body>
+        <h1>Second</h1>
+		<h:outputText value="#{flash['aaa']}"/>
+    </h:body>
+</html>

--- a/test/agnostic/flash/wrappedExtContext/src/test/java/com/sun/faces/test/agnostic/flash/wrappedExtContext/Issue18611757IT.java
+++ b/test/agnostic/flash/wrappedExtContext/src/test/java/com/sun/faces/test/agnostic/flash/wrappedExtContext/Issue18611757IT.java
@@ -1,0 +1,109 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 1997-2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package com.sun.faces.test.agnostic.flash.wrappedExtContext;
+
+import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+public class Issue18611757IT {
+    /**
+     * Stores the web URL.
+     */
+    private String webUrl;
+    /**
+     * Stores the web client.
+     */
+    private WebClient webClient;
+
+    /**
+     * Setup before testing.
+     * 
+     * @throws Exception when a serious error occurs.
+     */
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+    }
+
+    /**
+     * Cleanup after testing.
+     * 
+     * @throws Exception when a serious error occurs.
+     */
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    /**
+     * Setup before testing.
+     */
+    @Before
+    public void setUp() {
+        webUrl = System.getProperty("integration.url");
+        webClient = new WebClient();
+    }
+
+    /**
+     * Tear down after testing.
+     */
+    @After
+    public void tearDown() {
+        webClient.closeAllWindows();
+    }
+
+    @Test
+    public void testBuilderDefinedFlowWithMethodCall() throws Exception {
+        HtmlPage page = webClient.getPage(webUrl);
+        HtmlSubmitInput button = (HtmlSubmitInput) page.getElementById("submit");
+        page = button.click();
+        String pageXml = page.asXml();
+
+        assertTrue(pageXml.indexOf("xxx") != -1);
+        
+    }
+}


### PR DESCRIPTION
EAP 6.4.x BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1270758
Upstream JIRA: https://java.net/jira/browse/JAVASERVERFACES-3531
## SECTION: ModifiSed Files

M       jsf-ri/src/main/java/com/sun/faces/context/flash/ELFlash.java
- In setCookie() account for a problem introduced in 2.1 (fixed in 2.2):
  
  In 2.1 we added ExternalContext.isSecure() but neglected to add
  ExternalContextWrapper.isSecure().  Thus, parties that wrap
  ExternalContext, yet fail to override isSecure() (and
  setSessionMaxInterval() (also fixed in 2.2)) will get an
  UnsupportedOperationException without this fix.
  
  The fix is to inspect the return from ExternalContext.getRequest().
  If it is a ServletRequest, just go ahead and call isSecure().  If not,
  only call ExternalContext.isSecure() if the ExternalContext is not
  wrapped.

A       test/agnostic/flash/wrappedExtContext
A       test/agnostic/flash/wrappedExtContext/nbactions.xml
A       test/agnostic/flash/wrappedExtContext/src
A       test/agnostic/flash/wrappedExtContext/src/test
A       test/agnostic/flash/wrappedExtContext/src/test/java
A       test/agnostic/flash/wrappedExtContext/src/test/java/com
A       test/agnostic/flash/wrappedExtContext/src/test/java/com/sun
A       test/agnostic/flash/wrappedExtContext/src/test/java/com/sun/faces
A       test/agnostic/flash/wrappedExtContext/src/test/java/com/sun/faces/test
A       test/agnostic/flash/wrappedExtContext/src/test/java/com/sun/faces/test/agnostic
A       test/agnostic/flash/wrappedExtContext/src/test/java/com/sun/faces/test/agnostic/flash
A       test/agnostic/flash/wrappedExtContext/src/test/java/com/sun/faces/test/agnostic/flash/wrappedExtContext
A       test/agnostic/flash/wrappedExtContext/src/test/java/com/sun/faces/test/agnostic/flash/wrappedExtContext/Issue18611757IT.java
A       test/agnostic/flash/wrappedExtContext/src/main
A       test/agnostic/flash/wrappedExtContext/src/main/resources
A       test/agnostic/flash/wrappedExtContext/src/main/webapp
A       test/agnostic/flash/wrappedExtContext/src/main/webapp/first.xhtml
A       test/agnostic/flash/wrappedExtContext/src/main/webapp/second.xhtml
A       test/agnostic/flash/wrappedExtContext/src/main/webapp/WEB-INF
A       test/agnostic/flash/wrappedExtContext/src/main/webapp/WEB-INF/web.xml
A       test/agnostic/flash/wrappedExtContext/src/main/webapp/WEB-INF/glassfish-web.xml
A       test/agnostic/flash/wrappedExtContext/src/main/webapp/WEB-INF/faces-config.xml
A       test/agnostic/flash/wrappedExtContext/src/main/java
A       test/agnostic/flash/wrappedExtContext/src/main/java/cic1440b
A       test/agnostic/flash/wrappedExtContext/src/main/java/cic1440b/MyPortletRequest.java
A       test/agnostic/flash/wrappedExtContext/src/main/java/cic1440b/MyExternalContext.java
A       test/agnostic/flash/wrappedExtContext/src/main/java/cic1440b/Cic1440bBean.java
A       test/agnostic/flash/wrappedExtContext/src/main/java/cic1440b/MyExternalContextFactory.java
A       test/agnostic/flash/wrappedExtContext/pom.xml
M       test/agnostic/flash/pom.xml
- New test.  Way more work than the actual fix, but necessary on such an
  old code line.

git-svn-id: https://svn.java.net/svn/mojarra~svn/branches/MOJARRA_2_1X_ROLLING@13370 761efcf2-d34d-6b61-9145-99dcacc3edf1
