### PR TITLE
[JBEAP-10758] Duplicate ID exception when using composite component w…

### DIFF
--- a/jsf-ri/src/main/java/com/sun/faces/facelets/tag/jsf/ComponentSupport.java
+++ b/jsf-ri/src/main/java/com/sun/faces/facelets/tag/jsf/ComponentSupport.java
@@ -173,8 +173,9 @@ public final class ComponentSupport {
                 Map<String, Object> attrs = fc.getAttributes();
                 if (attrs.containsKey(MARK_DELETED)) {
                     itr.remove();
-                } else if (attrs.containsKey(IMPLICIT_PANEL) &&
-                           !curEntry.getKey().equals(UIViewRoot.METADATA_FACET_NAME)) {
+               } else if (UIComponent.COMPOSITE_FACET_NAME.equals(curEntry.getKey()) ||
+                          (attrs.containsKey(IMPLICIT_PANEL) &&
+                           !curEntry.getKey().equals(UIViewRoot.METADATA_FACET_NAME))) {
                     List<UIComponent> implicitPanelChildren = fc.getChildren();
                     UIComponent innerChild;
                     for (Iterator<UIComponent> innerItr = implicitPanelChildren.iterator();
@@ -421,14 +422,27 @@ public final class ComponentSupport {
 
         // mark all facets to be deleted
         if (c.getFacets().size() > 0) {
-            Collection col = c.getFacets().values();
+            Set col = c.getFacets().entrySet();
             UIComponent fc;
             for (Iterator itr = col.iterator(); itr.hasNext();) {
-                fc = (UIComponent) itr.next();
+               Map.Entry entry = (Map.Entry) itr.next();
+               String facet = (String) entry.getKey();
+                fc = (UIComponent) entry.getValue();
                 Map<String, Object> attrs = fc.getAttributes();
                 if (attrs.containsKey(MARK_CREATED)) {
                     attrs.put(MARK_DELETED, Boolean.TRUE);
-                } else if (attrs.containsKey(IMPLICIT_PANEL)) {
+                } else if (UIComponent.COMPOSITE_FACET_NAME.equals(facet)) {
+                   // mark the inner pannel components to be deleted
+                   sz = fc.getChildCount();
+                    if (sz > 0) {
+                        UIComponent cc = null;
+                        List cl = fc.getChildren();
+                        while (--sz >= 0) {
+                            cc = (UIComponent) cl.get(sz);
+                            cc.getAttributes().put(MARK_DELETED, Boolean.TRUE);
+                        }
+                    }
+               } else if (attrs.containsKey(IMPLICIT_PANEL)) {
                     List<UIComponent> implicitPanelChildren = fc.getChildren();
                     Map<String, Object> innerAttrs = null;
                     for (UIComponent cur : implicitPanelChildren) {


### PR DESCRIPTION
…ith c:if

JIRA: https://issues.jboss.org/browse/JBEAP-10758
upstream: https://java.net/jira/browse/JAVASERVERFACES-4240

https://java.net/jira/browse/JAVASERVERFACES-4240 Duplicate ID exception when using composite component with c:if
https://java.net/jira/browse/JAVASERVERFACES-4072 Error Component already found when using c:if in composite components
https://java.net/jira/browse/JAVASERVERFACES-3978 Using c:if: Component ID * has already been found in the view
https://java.net/jira/browse/JAVASERVERFACES-3940 Dynamic <ui:include> duplicates a composite component
https://java.net/jira/browse/JAVASERVERFACES-4204 Dynamic Composite Component in ui:include lead to duplicate id Exception

author:rickyepoderi https://java.net/jira/secure/ViewProfile.jspa?name=rickyepoderi
review:xinyuan.zhang
(cherry picked from commit 14e87ea57319012f02f0e3b09522d67c6d960378)