### PR TITLE
Replace hardcoded version in jsf-ri build.xml

### DIFF
--- a/jsf-ri/build.xml
+++ b/jsf-ri/build.xml
@@ -329,7 +329,7 @@
         <!-- Massage the version number into LogStrings.properties -->
         <replace dir="${build.classes.dir}/com/sun/faces/"
                  token="|version.string|"
-                 value="2.2.12.SP5 ${build.number}">
+                 value="${logging.version} ${build.number}">
             <include name="LogStrings*.properties"/>
         </replace>
 

--- a/pom.xml
+++ b/pom.xml
@@ -345,6 +345,7 @@
                   </classpath>
                 </taskdef>
                 <propertyregex property="build.jbossorg" input="${project.version}" regexp=".*(.SP.*)" select="\1" />
+                <propertyregex property="logging.version" input="${project.version}" regexp="(.*.SP\d+?)(-SNAPSHOT)?" select="\1" />
                 <propertyfile file="${project.basedir}/build.properties" comment="${project.name}-${project.version} properties">
                   <entry key="jsf.build.home" value="${user.dir}" />
                   <entry key="jsf-tools.jar" value="${project.basedir}/jsf-tools/target/jsf-tools-${project.version}.jar" />
@@ -352,6 +353,7 @@
                   <entry key="build.number" value="" />
                   <entry key="build.type" value="${build.jbossorg}" />
                   <entry key="compile.path" value="${compile.classpath}" />
+                  <entry key="logging.version" value="${logging.version}"/>
                 </propertyfile>
                 <ant antfile="${project.basedir}/build.xml" target="dist" inheritRefs="true" />
               </target>


### PR DESCRIPTION
@fjuma I think with this change the additional step of changing version if jsf-ri/build.xml won't be needed anymore. WDYT?