### PR TITLE
[WFLY-11136] It is not possible to build Mojarra with JDK10+

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -858,7 +858,7 @@
                     <dependency>
                         <groupId>org.apache.ant</groupId>
                         <artifactId>ant</artifactId>
-                        <version>1.9.6</version>
+                        <version>1.9.13</version>
                     </dependency>
                     <dependency>
                         <groupId>commons-digester</groupId>
@@ -872,7 +872,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>3.0.1</version>
+                <configuration>
+                    <doclint>none</doclint>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -890,7 +893,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -904,7 +907,7 @@
            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <excludes>
                         <exclude>javax/**</exclude>

--- a/jsf-tools/pom.xml
+++ b/jsf-tools/pom.xml
@@ -63,6 +63,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
                 <executions>
                     <execution>
                         <id>enforce-java-version</id>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.0.0-M2</version>
           <executions>
             <execution>
               <id>enforce-java-version</id>


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-11136