### PR TITLE
[WFLY-11516] Unuseful log "used for class com.sun.faces.flow.FlowDisc…

### DIFF
--- a/jsf-ri/src/main/java/com/sun/faces/flow/FlowDiscoveryCDIExtension.java
+++ b/jsf-ri/src/main/java/com/sun/faces/flow/FlowDiscoveryCDIExtension.java
@@ -100,7 +100,7 @@ public class FlowDiscoveryCDIExtension implements Extension {
     
     void beforeBeanDiscovery(@Observes final BeforeBeanDiscovery event, BeanManager beanManager) {
         AnnotatedType flowDiscoveryHelper = beanManager.createAnnotatedType(FlowDiscoveryCDIHelper.class);
-        event.addAnnotatedType(flowDiscoveryHelper);
+        event.addAnnotatedType(flowDiscoveryHelper, null);
         
     }
     


### PR DESCRIPTION
…overyCDIHelper is deprecated from CDI 1.1"

JIRA: https://issues.jboss.org/browse/WFLY-11516