### PR TITLE
[JBEAP-17019][issue-4577] Protected view JSF page can not be accessed…

### DIFF
--- a/jsf-ri/src/main/java/com/sun/faces/lifecycle/RestoreViewPhase.java
+++ b/jsf-ri/src/main/java/com/sun/faces/lifecycle/RestoreViewPhase.java
@@ -93,6 +93,7 @@ import com.sun.faces.renderkit.RenderKitUtils;
 import com.sun.faces.util.FacesLogger;
 import com.sun.faces.util.MessageUtils;
 import com.sun.faces.util.Util;
+import static com.sun.faces.util.Util.isOneOf;
 
 /**
  * <B>Lifetime And Scope</B> <P> Same lifetime and scope as
@@ -415,7 +416,9 @@ public class RestoreViewPhase extends Phase {
             hostsMatch = uri.getHost().equals(extContext.getRequestServerName());    
         }
         if (-1 == uri.getPort()) {
-            portsMatch = false;
+            //When running on default http/https ports the uri will not contain the port number
+            // to verify run test-javaee7-protectedView.war on port 80
+        	portsMatch = isOneOf(extContext.getRequestServerPort(), 80, 443);
         } else {
             portsMatch = uri.getPort() == extContext.getRequestServerPort();
         }

--- a/jsf-ri/src/main/java/com/sun/faces/util/Util.java
+++ b/jsf-ri/src/main/java/com/sun/faces/util/Util.java
@@ -478,6 +478,24 @@ public class Util {
         return valueExpression;
     }
     
+    /**
+     * Returns <code>true</code> if the given object equals one of the given objects.
+     * @param <T> The generic object type.
+     * @param object The object to be checked if it equals one of the given objects.
+     * @param objects The argument list of objects to be tested for equality.
+     * @return <code>true</code> if the given object equals one of the given objects.
+     */
+    @SafeVarargs
+    public static <T> boolean isOneOf(T object, T... objects) {
+        for (Object other : objects) {
+            if (object == null ? other == null : object.equals(other)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+    
     public static <T> List<T> reverse(List<T> list) {
         int length = list.size();
         List<T> result = new ArrayList<>(length);


### PR DESCRIPTION
… with port 80

Upstream issue: https://github.com/eclipse-ee4j/mojarra/issues/4577
[Upstream PR: 2.3 PR: https://github.com/eclipse-ee4j/mojarra/pull/4579,
master PR: https://github.com/eclipse-ee4j/mojarra/pull/4578]
Issue: https://issues.jboss.org/browse/JBEAP-17019

RestoreViewPhase is ignoring default ports 443 and 80
To validate run test Bug22995287IT on port 80 by setting integration.url=http://host/test-javaee7-protectedView