### PR TITLE
[JBEAP-17339] Mojarra 4553 - Resoures#encodeAll doesn't work anymore …

### DIFF
--- a/jsf-api/src/main/java/javax/faces/component/UIViewRoot.java
+++ b/jsf-api/src/main/java/javax/faces/component/UIViewRoot.java
@@ -968,7 +968,8 @@ public class UIViewRoot extends UIComponentBase implements UniqueIdVendor {
     public void processEvent(ComponentSystemEvent event) throws AbortProcessingException {
         FacesContext context = event.getFacesContext();
 
-        if (event instanceof PostRestoreStateEvent && context.getPartialViewContext().isPartialRequest()) {
+        if (event instanceof PostRestoreStateEvent && context.getPartialViewContext().isPartialRequest()
+                 && !context.getPartialViewContext().isRenderAll()) {
             ResourceHandler resourceHandler = context.getApplication().getResourceHandler();
 
             for (UIComponent resource : getComponentResources(context)) {

--- a/test/unit/src/test/java/com/sun/faces/mock/MockPartialViewContext.java
+++ b/test/unit/src/test/java/com/sun/faces/mock/MockPartialViewContext.java
@@ -53,6 +53,8 @@ import javax.faces.event.PhaseId;
 public class MockPartialViewContext extends PartialViewContext {
 
     private Map<Object, Object> attributes;
+    private boolean partial = false;
+    private boolean renderAll = false;
 
     // ------------------------------------------------------------ Constructors
     public MockPartialViewContext() {
@@ -102,7 +104,7 @@ public class MockPartialViewContext extends PartialViewContext {
     }
 
     public boolean isPartialRequest() {
-        return false;
+        return partial;
     }
 
     public boolean isExecuteNone() {
@@ -114,11 +116,11 @@ public class MockPartialViewContext extends PartialViewContext {
     }
 
     public boolean isRenderAll() {
-        throw new UnsupportedOperationException();
+        return renderAll;
     }
 
     public void setRenderAll(boolean renderAll) {
-        throw new UnsupportedOperationException();
+        this.renderAll = renderAll;
     }
 
     public boolean isRenderNone() {
@@ -138,7 +140,8 @@ public class MockPartialViewContext extends PartialViewContext {
     }
 
     @Override
-    public void setPartialRequest(boolean arg0) {
+    public void setPartialRequest(boolean partial) {
+        this.partial = partial;
     }
 
 }

--- a/test/unit/src/test/java/javax/faces/component/UIViewRootTestCase.java
+++ b/test/unit/src/test/java/javax/faces/component/UIViewRootTestCase.java
@@ -45,8 +45,10 @@ import java.util.List;
 import java.util.Locale;
 import java.io.IOException;
 import javax.faces.FactoryFinder;
+import javax.faces.application.ResourceHandler;
 import javax.faces.event.PhaseEvent;
 import javax.faces.event.PhaseListener;
+import javax.faces.event.PostRestoreStateEvent;
 import javax.faces.context.FacesContext;
 import javax.faces.event.PhaseId;
 import junit.framework.Test;
@@ -181,6 +183,43 @@ public class UIViewRootTestCase extends UIComponentBaseTestCase {
         assertNotNull(root.getFacet("javax_faces_location_gt"));
         components = root.getComponentResources(facesContext, "gt");
         assertTrue(components.size() == 1);
+    }
+    
+    // Tests that the resources are rendered again if renderall, @all, is set
+    public void testRenderAllComponentResources() {
+        application.addComponent("javax.faces.ComponentResourceContainer", Container.class.getName());
+        UIViewRoot previousRoot = facesContext.getViewRoot();
+        UIViewRoot root = facesContext.getApplication().getViewHandler().createView(facesContext, null);
+        //from partial-request we get the resources added to the ViewRoot
+        facesContext.setViewRoot(root);
+        UIOutput script = new UIOutput();
+        script.getAttributes().putIfAbsent("name", "scriptTest");
+        script.getAttributes().putIfAbsent("library", "scriptLibrary");
+
+        root.addComponentResource(facesContext, script);
+
+        facesContext.getPartialViewContext().setPartialRequest(true);
+        //update @all
+        facesContext.getPartialViewContext().setRenderAll(true);
+
+        final PostRestoreStateEvent postRestoreStateEvent = new PostRestoreStateEvent(root);
+        ResourceHandler resourceHandler = facesContext.getApplication().getResourceHandler();
+
+        postRestoreStateEvent.setComponent(root);
+        root.processEvent(postRestoreStateEvent);
+
+        assertFalse("Resource should not be marked as rendered", resourceHandler.isResourceRendered(facesContext, "scriptTest", "scriptLibrary"));
+
+        //partial update i.e. @form
+        facesContext.getPartialViewContext().setRenderAll(false);
+        root.processEvent(postRestoreStateEvent);
+
+        assertTrue("Resource should be marked as rendered", resourceHandler.isResourceRendered(facesContext, "scriptTest", "scriptLibrary"));
+
+        facesContext.getPartialViewContext().setPartialRequest(false);
+        facesContext.getPartialViewContext().setRenderAll(false);
+        facesContext.setViewRoot(previousRoot);
+
     }
 
     // Test AbortProcessingException support


### PR DESCRIPTION
…since 2.3.x

Upstream issue: https://github.com/eclipse-ee4j/mojarra/issues/4553
[Upstream PR: https://github.com/eclipse-ee4j/mojarra/pull/4630]
Issue: https://issues.jboss.org/browse/JBEAP-17339

2.3.9 PR: https://github.com/jboss/mojarra/pull/44