### PR TITLE
[JBEAP-17856] Memory leak in FlashScope when response is already comm…

### DIFF
--- a/jsf-ri/src/main/java/com/sun/faces/context/flash/ELFlash.java
+++ b/jsf-ri/src/main/java/com/sun/faces/context/flash/ELFlash.java
@@ -1080,6 +1080,12 @@ public class ELFlash extends Flash {
                     LOGGER.log(Level.WARNING,
                             "jsf.externalcontext.flash.response.already.committed");
                 }
+                if (nextFlash != null) {
+                    flashManager.expireNext();
+                }
+                if (prevFlash != null) {
+                    flashManager.expirePrevious();
+                }
             } else {
                 Map<String, Object> properties = new HashMap();
                 Object val;


### PR DESCRIPTION
…itted

Issue: https://issues.jboss.org/browse/JBEAP-17856
Upstream PR: https://github.com/eclipse-ee4j/mojarra/pull/4653, #50 
Upstream Issue: https://github.com/eclipse-ee4j/mojarra/issues/4652, https://issues.jboss.org/browse/JBEAP-17907