### PR TITLE
[JBEAP-17907] Memory leak in FlashScope when response is already comm…

### DIFF
--- a/impl/src/main/java/com/sun/faces/context/flash/ELFlash.java
+++ b/impl/src/main/java/com/sun/faces/context/flash/ELFlash.java
@@ -1056,6 +1056,12 @@ public class ELFlash extends Flash {
                     LOGGER.log(Level.WARNING,
                             "jsf.externalcontext.flash.response.already.committed");
                 }
+                if (nextFlash != null) {
+                    flashManager.expireNext();
+                }
+                if (prevFlash != null) {
+                    flashManager.expirePrevious();
+                }
             } else {
                 Map<String, Object> properties = new HashMap();
                 Object val;


### PR DESCRIPTION
…itted

Issue: https://issues.jboss.org/browse/JBEAP-17907
Upstream: https://github.com/eclipse-ee4j/mojarra/issues/4652
Upstream PR: https://github.com/eclipse-ee4j/mojarra/pull/4653