### PR TITLE
[JBEAP-17971] Mojarra Issue 4650 / ArrayIndexOutOfBoundsException with index -2 in HtmlResponseWriter.writeUnescapedCData(...)

### DIFF
--- a/jsf-ri/src/main/java/com/sun/faces/renderkit/html_basic/HtmlResponseWriter.java
+++ b/jsf-ri/src/main/java/com/sun/faces/renderkit/html_basic/HtmlResponseWriter.java
@@ -940,6 +940,8 @@ public class HtmlResponseWriter extends ResponseWriter {
         }
         closeStartIfNecessary();
 
+        if (text.length == 0) return;
+
         if (dontEscape) {
             if (writingCdata) {
                 writeUnescapedCData(text, 0, text.length);
@@ -980,6 +982,8 @@ public class HtmlResponseWriter extends ResponseWriter {
         }
         closeStartIfNecessary();
         String textStr = text.toString();
+
+        if (textStr.length() == 0) return;
 
         if (dontEscape) {
             if (writingCdata) {

--- a/test/unit/src/test/java/com/sun/faces/renderkit/html_basic/HtmlResponseWriterTest.java
+++ b/test/unit/src/test/java/com/sun/faces/renderkit/html_basic/HtmlResponseWriterTest.java
@@ -178,6 +178,9 @@ public class HtmlResponseWriterTest {
         HtmlResponseWriter responseWriter = new HtmlResponseWriter(stringWriter, "application/xhtml+xml", "UTF-8");
         responseWriter.startElement("style", null);
         responseWriter.startCDATA();
+        // make sure empty string is handle correct
+        responseWriter.writeText("".toCharArray());
+        responseWriter.writeText("", null);
         responseWriter.writeText(']', null);
         responseWriter.endCDATA();
         responseWriter.endElement("style");


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-17971
Upstream Issue: https://github.com/eclipse-ee4j/mojarra/issues/4650
Upstream PR: https://github.com/eclipse-ee4j/mojarra/pull/4657

Backport of upstream issue 4650 to 2.3.5.SP.