### PR TITLE
JBEAP-17499 2nd part fix for TCK failure, If the component is NOT val…

### DIFF
--- a/jsf-api/src/main/java/javax/faces/component/UIInput.java
+++ b/jsf-api/src/main/java/javax/faces/component/UIInput.java
@@ -1050,7 +1050,7 @@ public class UIInput extends UIOutput implements EditableValueHolder {
             }
         }
 
-        if (compareValues(previous, newValue)) {
+        if (isValid() && compareValues(previous, newValue)) {
             queueEvent(new ValueChangeEvent(context, this, previous, newValue));
         }
 


### PR DESCRIPTION
2nd part fix for TCK failure, If the component is NOT valid, the associated ValueChangeListener must NOT be invoked

Issue: https://issues.redhat.com/browse/JBEAP-17499
Upstream issue: https://issues.redhat.com/browse/JBEAP-17931

Upstream 2.3.9.SP PR: https://github.com/jboss/mojarra/pull/59

Upstream eclipse-ee4j/mojarra PR: https://github.com/eclipse-ee4j/mojarra/pull/4681