### PR TITLE
[WFLY-13571] make the extra validation only on UIViewParameter.

### DIFF
--- a/impl/src/main/java/javax/faces/component/UIInput.java
+++ b/impl/src/main/java/javax/faces/component/UIInput.java
@@ -986,8 +986,9 @@ public class UIInput extends UIOutput implements EditableValueHolder {
             if (isRequired() && isSetAlwaysValidateRequired(context)) {
                 // continue as below
             } else {
-                if(considerEmptyStringNull(context)) {
+                if (this instanceof UIViewParameter && considerEmptyStringNull(context)) {
                     // https://github.com/eclipse-ee4j/mojarra/issues/4550
+                    // https://github.com/eclipse-ee4j/mojarra/issues/4716
                     validateValue(context,  getConvertedValue(context, submittedValue));
                 }
                 return;


### PR DESCRIPTION
JBEAP issue: https://issues.redhat.com/browse/JBEAP-19593
Upstream WFLY issue: https://issues.redhat.com/browse/WFLY-13571

Upstream PR: https://github.com/eclipse-ee4j/mojarra/pull/4717

Last pull request https://github.com/jboss/mojarra/pull/72 addressed the JAVASERVERFACES_SPEC_PUBLIC-1329 validation requirement inside UIInput.java rather than UIViewParameter.java. However, the extra validation should have only applied on UIViewParameter.

@fjuma My apologies to bug you again about this, could review please. 