### PR TITLE
Fix PropertyNotFoundException when nested entity is null while basic

### DIFF
--- a/test/javaee8/uiinput/src/main/java/com/sun/faces/test/javaee8/uiinput/Issue4734.java
+++ b/test/javaee8/uiinput/src/main/java/com/sun/faces/test/javaee8/uiinput/Issue4734.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.faces.test.javaee8.uiinput;
+
+import java.io.Serializable;
+
+import javax.annotation.PostConstruct;
+import javax.faces.view.ViewScoped;
+import javax.inject.Named;
+
+@Named
+@ViewScoped
+public class Issue4734 implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Issue4734Entity entity;
+
+    @PostConstruct
+    public void init() {
+        entity = new Issue4734Entity(); // WARNING: unnatural approach, you'd expect that the converter would be used on f:viewParam, but it is part of the actual issue.
+    }
+
+    public Issue4734Entity getEntity() {
+        return entity;
+    }
+
+    public void setEntity(Issue4734Entity entity) {
+        this.entity = entity;
+    }
+}

--- a/test/javaee8/uiinput/src/main/java/com/sun/faces/test/javaee8/uiinput/Issue4734Entity.java
+++ b/test/javaee8/uiinput/src/main/java/com/sun/faces/test/javaee8/uiinput/Issue4734Entity.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.faces.test.javaee8.uiinput;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class Issue4734Entity implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+
+    public Issue4734Entity() {
+        //
+    }
+
+    public Issue4734Entity(Long id) {
+        this.id = id;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof Issue4734Entity && Objects.equals(id, ((Issue4734Entity) other).id);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[" + id + "]";
+    }
+}

--- a/test/javaee8/uiinput/src/main/java/com/sun/faces/test/javaee8/uiinput/Issue4734EntityConverter.java
+++ b/test/javaee8/uiinput/src/main/java/com/sun/faces/test/javaee8/uiinput/Issue4734EntityConverter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.faces.test.javaee8.uiinput;
+
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.convert.Converter;
+import javax.faces.convert.FacesConverter;
+
+@FacesConverter(forClass=Issue4734Entity.class)
+public class Issue4734EntityConverter implements Converter {
+
+    @Override
+    public String getAsString(FacesContext context, UIComponent component, Object modelValue) {
+        Long id = modelValue == null ? null : ((Issue4734Entity) modelValue).getId();
+        return id == null ? "" : id.toString();
+    }
+
+    @Override
+    public Object getAsObject(FacesContext context, UIComponent component, String submittedValue) {
+        Long id = submittedValue == null || submittedValue.isEmpty() ? null : Long.valueOf(submittedValue);
+        return id == null ? null : new Issue4734Entity(id);
+    }
+
+}

--- a/test/javaee8/uiinput/src/main/webapp/issue4734.xhtml
+++ b/test/javaee8/uiinput/src/main/webapp/issue4734.xhtml
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<!-- 
+    Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2020 Contributors to the Eclipse Foundation.
+    
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ -->
+<html lang="en"
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:f="http://xmlns.jcp.org/jsf/core"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+>
+    <f:metadata>
+        <f:viewParam name="id" value="#{issue4734.entity.id}" />
+    </f:metadata>
+
+    <h:head>
+        <title>Issue4734 - f:viewParam should not throw "Target Unreachable, 'null' returned null" when below form is submitted at least twice.</title>
+    </h:head>
+
+    <h:body>
+        <h:form id="form">
+            <h:selectOneMenu value="#{issue4734.entity}">
+                <f:selectItem itemValue="#{null}" />
+            </h:selectOneMenu>
+            <h:commandButton id="submit" />
+        </h:form>
+    </h:body>
+</html>

--- a/test/javaee8/uiinput/src/test/java/com/sun/faces/test/javaee8/uiinput/Issue4734IT.java
+++ b/test/javaee8/uiinput/src/test/java/com/sun/faces/test/javaee8/uiinput/Issue4734IT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.faces.test.javaee8.uiinput;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
+import com.sun.faces.test.htmlunit.IgnoringIncorrectnessListener;
+import com.sun.faces.test.junit.JsfTestRunner;
+
+@RunWith(JsfTestRunner.class)
+public class Issue4734IT {
+
+    private String webUrl;
+    private WebClient webClient;
+
+    @Before
+    public void setUp() {
+        webUrl = System.getProperty("integration.url");
+        webClient = new WebClient();
+        webClient.getOptions().setJavaScriptEnabled(true);
+        webClient.setJavaScriptTimeout(60000);
+        webClient.setIncorrectnessListener(new IgnoringIncorrectnessListener());
+    }
+
+    @Test
+    public void testIssue4734() throws Exception {
+        HtmlPage page = webClient.getPage(webUrl + "issue4734.xhtml");
+        HtmlSubmitInput submit = page.getHtmlElementById("form:submit");
+
+        submit.click(); // The first click is expected to work fine.
+
+        submit.click(); // Before the fix, the second click failed with com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException: 500 Internal Server Error
+
+        submit.click(); // A third one, just to be sure it keeps working! ;)
+    }
+
+    @After
+    public void tearDown() {
+        webClient.close();
+    }
+
+}


### PR DESCRIPTION
input renderer attempts to locate the converter by value expression type
even though the submitted value is null

(cherry picked from commit 29052d0e82d3f82267488c557474dda35d560172)

issue: https://issues.redhat.com/browse/WFLY-13691

backport upstream fix for WFLY-13691

upstream issue: https://github.com/eclipse-ee4j/mojarra/issues/4734
upstream PR: https://github.com/eclipse-ee4j/mojarra/pull/4801