### PR TITLE
[Issue 4812] New WARNING error message on undeploy when there are duplicate registrations of ConfigureListener

### DIFF
--- a/impl/src/main/java/com/sun/faces/config/ConfigureListener.java
+++ b/impl/src/main/java/com/sun/faces/config/ConfigureListener.java
@@ -359,10 +359,8 @@ public class ConfigureListener implements ServletRequestListener, HttpSessionLis
             if( configManager != null ) {
               configManager.destroy(context, initContext);
               ConfigManager.removeInstance(context);
-            } else {
-              if (LOGGER.isLoggable(WARNING)) {
-                  LOGGER.log(WARNING, "Unexpected state during contextDestroyed: no ConfigManager instance in current ServletContext but one is expected to exist.");
-              }
+            } else if (WebConfiguration.getInstanceWithoutCreating(context) != null && LOGGER.isLoggable(WARNING)) {
+                LOGGER.log(WARNING, "Unexpected state during contextDestroyed: no ConfigManager instance in current ServletContext but one is expected to exist.");
             }
             FactoryFinder.releaseFactories();
             ReflectionUtils.clearCache(Thread.currentThread().getContextClassLoader());


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-20561
Upstream Issue: https://github.com/eclipse-ee4j/mojarra/issues/4812
Upstream PR: https://github.com/eclipse-ee4j/mojarra/pull/4813

Changes to avoid the WARNING message when a JSF application is undeployed and the FacesServlet is not present in the web.xml.