### PR TITLE
Remove/modify CDI bits that are to be removed in CDI API 4.x.

### DIFF
--- a/impl/src/main/java/com/sun/faces/cdi/CdiProducer.java
+++ b/impl/src/main/java/com/sun/faces/cdi/CdiProducer.java
@@ -148,12 +148,7 @@ abstract class CdiProducer<T> implements Bean<T>, PassivationCapable, Serializab
         return false;
     }
 
-    /**
-     * Is this nullable.
-     *
-     * @return false.
-     */
-    @Override
+    // TODO to be removed once using CDI API 4.x
     public boolean isNullable() {
         return false;
     }

--- a/impl/src/main/java/com/sun/faces/flow/FlowDiscoveryCDIExtension.java
+++ b/impl/src/main/java/com/sun/faces/flow/FlowDiscoveryCDIExtension.java
@@ -74,7 +74,7 @@ public class FlowDiscoveryCDIExtension implements Extension {
 
     void beforeBeanDiscovery(@Observes final BeforeBeanDiscovery event, BeanManager beanManager) {
         AnnotatedType flowDiscoveryHelper = beanManager.createAnnotatedType(FlowDiscoveryCDIHelper.class);
-        event.addAnnotatedType(flowDiscoveryHelper);
+        event.addAnnotatedType(flowDiscoveryHelper, FlowDiscoveryCDIHelper.class.toString());
 
     }
 

--- a/impl/src/main/java/com/sun/faces/push/WebsocketSessionManager.java
+++ b/impl/src/main/java/com/sun/faces/push/WebsocketSessionManager.java
@@ -282,8 +282,8 @@ public class WebsocketSessionManager {
 
     private static void fireEvent(Session session, CloseReason reason, AnnotationLiteral<?> qualifier) {
         Serializable user = (Serializable) session.getUserProperties().get("user");
-        Util.getCdiBeanManager(FacesContext.getCurrentInstance())
-                .fireEvent(new WebsocketEvent(getChannel(session), user, reason != null ? reason.getCloseCode() : null), qualifier);
+        Util.getCdiBeanManager(FacesContext.getCurrentInstance()).getEvent().select(WebsocketEvent.class, qualifier)
+                .fire(new WebsocketEvent(getChannel(session), user, reason != null ? reason.getCloseCode() : null));
     }
 
 }

--- a/impl/src/main/java/com/sun/faces/util/cdi11/CDIUtilImpl.java
+++ b/impl/src/main/java/com/sun/faces/util/cdi11/CDIUtilImpl.java
@@ -127,7 +127,7 @@ public class CDIUtilImpl implements Serializable, CDIUtil {
             return false;
         }
 
-        @Override
+        // TODO to be removed once using CDI API 4.x
         public boolean isNullable() {
             return false;
         }


### PR DESCRIPTION
I was testing WFLY with latest CDI API (4.0.0.Alpha1) where there was a number of removals of long deprecated methods.
See https://github.com/eclipse-ee4j/cdi/issues/472

This causes JSF impl to crash during TCK runs so I had to create a custom artifact and replace it within WFLY - this PR a sum of changes I needed to make it work.

@fjuma I am not sure this has any value on this fork (as I have no idea how you upkeep this versus the actual origin) but I thought you might be interested in it; take it or leave it.
Oh and I should note - the current state of this PR will work with CDI 3 as well as CDI 4 so there should be no harm having it applied right away ;-)