### PR TITLE
[WFLY-16061] Fix WELD warning about usage of deprecated CDI method

### DIFF
--- a/impl/src/main/java/com/sun/faces/flow/FlowDiscoveryCDIExtension.java
+++ b/impl/src/main/java/com/sun/faces/flow/FlowDiscoveryCDIExtension.java
@@ -16,15 +16,14 @@
 
 package com.sun.faces.flow;
 
+import static com.sun.faces.cdi.CdiUtils.addAnnotatedTypes;
+
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.sun.faces.util.FacesLogger;
-
 import jakarta.enterprise.event.Observes;
-import jakarta.enterprise.inject.spi.AnnotatedType;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
 import jakarta.enterprise.inject.spi.Extension;
@@ -32,6 +31,8 @@ import jakarta.enterprise.inject.spi.ProcessProducer;
 import jakarta.enterprise.inject.spi.Producer;
 import jakarta.faces.flow.Flow;
 import jakarta.faces.flow.builder.FlowDefinition;
+
+import com.sun.faces.util.FacesLogger;
 
 /*
  *  This is the hook into the bootstrapping of the entire feature.
@@ -73,9 +74,7 @@ public class FlowDiscoveryCDIExtension implements Extension {
     }
 
     void beforeBeanDiscovery(@Observes final BeforeBeanDiscovery event, BeanManager beanManager) {
-        AnnotatedType flowDiscoveryHelper = beanManager.createAnnotatedType(FlowDiscoveryCDIHelper.class);
-        event.addAnnotatedType(flowDiscoveryHelper);
-
+        addAnnotatedTypes(event, beanManager, FlowDiscoveryCDIHelper.class);
     }
 
     <T> void findFlowDefiners(@Observes ProcessProducer<T, Flow> pp) {


### PR DESCRIPTION
https://github.com/eclipse-ee4j/mojarra/issues/4916

Despite the commit message (from the upstream commit), this doesn't just fix warnings; it prevents failures with CDI 4.