### PR TITLE
Fix #4260: AttachedObjectListHolder IndexOutOfBounds fix 2.3

### DIFF
--- a/impl/src/main/java/javax/faces/component/AttachedObjectListHolder.java
+++ b/impl/src/main/java/javax/faces/component/AttachedObjectListHolder.java
@@ -140,7 +140,7 @@ class AttachedObjectListHolder<T> implements PartialStateHolder {
                     add(restored);
                 }
             }
-        } else {
+        } else if (this.attachedObjects != null && this.attachedObjects.size() == attachedObjects.length) {
             // Assume 1:1 relation between existing attachedObjects and state
             for (int i = 0, len = attachedObjects.length; i < len; i++) {
                 T attachedObject = this.attachedObjects.get(i);


### PR DESCRIPTION
This is a back port of https://github.com/eclipse-ee4j/mojarra/pull/5102 to jboss fork