### PR TITLE
JBEAP-28797 Fix exception handling in WebappLifecycleListener.requestDestroyed()

### DIFF
--- a/impl/src/main/java/com/sun/faces/config/InitFacesContext.java
+++ b/impl/src/main/java/com/sun/faces/config/InitFacesContext.java
@@ -33,6 +33,7 @@ import javax.faces.application.Application;
 import javax.faces.application.ApplicationFactory;
 import javax.faces.application.ProjectStage;
 import javax.faces.component.UIViewRoot;
+import javax.faces.context.ExceptionHandler;
 import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
 import javax.servlet.ServletContext;
@@ -42,6 +43,7 @@ import com.sun.faces.config.initfacescontext.NoOpELContext;
 import com.sun.faces.config.initfacescontext.NoOpFacesContext;
 import com.sun.faces.config.initfacescontext.ServletContextAdapter;
 import com.sun.faces.context.ApplicationMap;
+import com.sun.faces.context.ExceptionHandlerImpl;
 import com.sun.faces.util.FacesLogger;
 import com.sun.faces.util.Util;
 
@@ -59,6 +61,8 @@ public class InitFacesContext extends NoOpFacesContext {
     private Map<Object, Object> attributes;
 
     private ELContext elContext = new NoOpELContext();
+
+    private ExceptionHandler exceptionHandler;
 
     public InitFacesContext(ServletContext servletContext) {
         servletContextAdapter = new ServletContextAdapter(servletContext);
@@ -167,7 +171,15 @@ public class InitFacesContext extends NoOpFacesContext {
     public void removeServletContextEntryForInitContext() {
         getInitContextServletContextMap().remove(this);
     }
-    
+
+    @Override
+    public ExceptionHandler getExceptionHandler() {
+        if (exceptionHandler == null) {
+            exceptionHandler = new ExceptionHandlerImpl(false);
+        }
+        return exceptionHandler;
+    }
+
     /**
      * Clean up entries from the threadInitContext and initContextServletContext maps using a ServletContext. First remove
      * entry(s) with matching ServletContext from initContextServletContext map. Then remove entries from threadInitContext

--- a/impl/src/main/java/com/sun/faces/config/initfacescontext/ServletContextAdapter.java
+++ b/impl/src/main/java/com/sun/faces/config/initfacescontext/ServletContextAdapter.java
@@ -258,6 +258,10 @@ public class ServletContextAdapter extends ExternalContext {
     }
 
     @Override
+    public void setResponseStatus(int statusCode) {
+    }
+
+    @Override
     public Object getSession(boolean create) {
         return null;
     }

--- a/impl/src/test/java/com/sun/faces/application/WebappLifecycleListenerTestCase.java
+++ b/impl/src/test/java/com/sun/faces/application/WebappLifecycleListenerTestCase.java
@@ -1,0 +1,75 @@
+package com.sun.faces.application;
+
+import com.sun.faces.config.InitFacesContext;
+import com.sun.faces.junit.JUnitFacesTestCaseBase;
+import com.sun.faces.mock.MockHttpServletRequest;
+import com.sun.faces.mock.MockServletContext;
+import junit.framework.Test;
+import junit.framework.TestSuite;
+import org.junit.Assert;
+
+import javax.faces.FacesException;
+import javax.faces.context.FacesContext;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletRequestEvent;
+
+public class WebappLifecycleListenerTestCase extends JUnitFacesTestCaseBase {
+
+    private final static String SYNTHETIC_EXCEPTION_MESSAGE = "Synthetic exception";
+
+    public WebappLifecycleListenerTestCase(String name) {
+        super(name);
+    }
+
+    // Return the tests included in this test case.
+    public static Test suite() {
+        return (new TestSuite(WebappLifecycleListenerTestCase.class));
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        // This closes the MockFacesContext created by this test setUp.
+        if (FacesContext.getCurrentInstance() != null) {
+            FacesContext.getCurrentInstance().release();
+        }
+
+        // This removes the InitFacesContext initialized in lifecycleListener.requestDestroyed(event) exception handling
+        // logic. Not removing it would affect following tests.
+        if (FacesContext.getCurrentInstance() instanceof InitFacesContext) {
+            ((InitFacesContext) FacesContext.getCurrentInstance()).removeInitContextEntryForCurrentThread();
+        }
+    }
+
+    /**
+     * Tests that exception handling in WebappLifecycleListener.requestDestroyed(event) works.
+     */
+    public void testRequestDestroyedExceptionHandling() {
+        // Create lifecycle listener and related objects.
+        WebappLifecycleListener lifecycleListener = new WebappLifecycleListener(null);
+
+        // Create a request event. Make it cause an exception inside the lifecycleListener.requestDestroyed(event) call.
+        ServletRequestEvent event = new ServletRequestEvent(new MockServletContext(), new MockHttpServletRequest()) {
+            @Override
+            public ServletRequest getServletRequest() {
+                // This is just a convenient place to throw the exception for testing purposes. In the real impl the
+                // exception would come from a surrounding code, not from this particular method.
+                throw new RuntimeException(SYNTHETIC_EXCEPTION_MESSAGE);
+            }
+        };
+
+        try {
+            // Call the requestDestroyed() lifecycle method. It should handle the synthetic exception thrown from
+            // event.getServletRequest() and rethrow it as FacesException.
+            // Certainly, we don't expect an UnsupportedOperationException from FacesContext.getExceptionHandler()
+            // instead.
+            lifecycleListener.requestDestroyed(event);
+            Assert.fail("We expect a FacesException to be thrown from lifecycleListener.requestDestroyed(event)");
+        } catch (FacesException e) {
+            // FacesException has been produced as expected. The exception message should be the original synthetic
+            // exception message.
+            Assert.assertEquals(SYNTHETIC_EXCEPTION_MESSAGE, e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-28797
Upstream issue: https://issues.redhat.com/browse/JBEAP-29435, https://issues.redhat.com/browse/JBEAP-29436, https://issues.redhat.com/browse/WFLY-20415
Upstream PR: https://github.com/eclipse-ee4j/mojarra/pull/5567

The exception handling in WebappLifecycleListener.requestDestroyed() is not working because the InitFacesContext doesn't have the getExceptionHandler() method implemented.

Checking upstream mojarra master the method has been implemented there: https://github.com/eclipse-ee4j/mojarra/blame/master/impl/src/main/java/com/sun/faces/config/InitFacesContext.java#L103

although that implementation is still not sufficient for this use case (we would need InitFacesContext to keep returning the same ExceptionHandler instance, rather than always creating a new instance).

So if this change looks reasonable I would follow up with upstream Mojarra tickets to fix the use case there as well.

BTW I don't know which branch to target with this PR, but EAP 7.4 is currently using 2.3.14.SP07, hence using 2.3.14.SP.

Cc @jasondlee 